### PR TITLE
google Maps script import 방식 useEffect로 개선 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script
-      src="https://maps.googleapis.com/maps/api/js?key=<%= GOOGLE_MAPS_API_KEY %>&language=ko&loading=async"
-      async
-      defer
-    ></script>
     <title>TRIPJ</title>
   </head>
   <body>

--- a/src/components/GoogleMapView.tsx
+++ b/src/components/GoogleMapView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import type { Event } from '../types/event.ts';
 import { geocodeAddress } from '../utils/map.ts';
 import { useThrottle } from '../hooks/useThrottle.tsx';
@@ -12,86 +12,113 @@ export const GoogleMapView = ({ events }: GoogleMapViewProps) => {
   const mapInstanceRef = useRef<google.maps.Map | null>(null);
   const markersRef = useRef<google.maps.marker.AdvancedMarkerElement[]>([]);
   const throttledEvents = useThrottle<Event[]>(events, 1000);
+  const [isMapReady, setIsMapReady] = useState<boolean>(false);
 
   const createPin = (event: Event) => {
     const pin = document.createElement('div');
-    pin.className =
-      'size-8 bg-primary-base rounded-full border-2 border-white ring-2 ring-primary-dark';
-
     pin.innerHTML = `
-    <div class="relative group">
-      <div class="size-3 bg-primary-base rounded-full border-2 border-white"></div>
-
-      <div class="
-        absolute bottom-6 left-1/2 -translate-x-1/2
-        hidden group-hover:block
-        bg-white p-3 rounded-lg shadow-lg
-        w-48 text-xs
-      ">
-        <div class="font-bold">${event.eventName}</div>
-        <div class="text-gray-500 mt-1">${event.location}</div>
+      <div class="relative group">
+        <div class="size-3 bg-primary-base rounded-full border-2 border-white"></div>
+        <div class="
+          absolute bottom-6 left-1/2 -translate-x-1/2
+          hidden group-hover:block
+          bg-white p-3 rounded-lg shadow-lg
+          w-48 text-xs
+        ">
+          <div class="font-bold">${event.eventName}</div>
+          <div class="text-gray-500 mt-1">${event.location}</div>
+        </div>
       </div>
-    </div>
-  `;
-
+    `;
     return pin;
   };
+  useEffect(() => {
+    const initGoogleMap = async () => {
+      if (!mapRef.current || mapInstanceRef.current) return;
 
-  const initGoogleMap = useCallback(async () => {
-    if (!mapRef.current || mapInstanceRef.current) return;
-    await google.maps.importLibrary('marker');
+      await loadGoogleMaps();
+      await google.maps.importLibrary('marker');
 
-    mapInstanceRef.current = new window.google.maps.Map(mapRef.current, {
-      // 광화문
-      center: { lat: 37.5665, lng: 126.978 },
-      zoom: 15,
-      mapId: import.meta.env.VITE_GOOGLE_MAP_ID,
-    });
+      mapInstanceRef.current = new google.maps.Map(mapRef.current, {
+        center: { lat: 37.5665, lng: 126.978 },
+        zoom: 15,
+        mapId: import.meta.env.VITE_GOOGLE_MAP_ID,
+      });
+
+      setIsMapReady(true);
+    };
+    initGoogleMap();
   }, []);
 
   useEffect(() => {
-    const checkIfGoogleIsLoaded = () => {
-      return typeof window.google === 'object' && typeof window.google.maps === 'object';
-    };
-    if (checkIfGoogleIsLoaded()) {
-      initGoogleMap();
-    }
-  }, [initGoogleMap]);
+    if (!isMapReady || !mapInstanceRef.current || throttledEvents.length === 0) return;
 
-  useEffect(() => {
-    if (!mapInstanceRef.current || throttledEvents.length === 0) return;
     const map = mapInstanceRef.current;
-    markersRef.current.forEach((marker) => {
-      marker.map = null;
-    });
+
+    markersRef.current.forEach((marker) => (marker.map = null));
     markersRef.current = [];
 
     const drawMarkers = async () => {
+      const bounds = new google.maps.LatLngBounds();
       const results = await Promise.allSettled(
         throttledEvents.map(async (event) => {
           if (!event.location || !event.eventName) return null;
-          try {
-            const position = await geocodeAddress(event.location);
-            return { position, event };
-          } catch (error) {
-            console.error('주소 변환 실패:', event.location, error);
-          }
+          const position = await geocodeAddress(event.location);
+          return { position, event };
         })
       );
+
       results.forEach((result) => {
-        if (result.status === 'rejected') return;
-        const res = result.value;
-        if (!res) return;
+        if (result.status !== 'fulfilled' || !result.value) return;
+
         const marker = new google.maps.marker.AdvancedMarkerElement({
           map,
-          position: res.position,
-          content: createPin(res.event),
+          position: result.value.position,
+          content: createPin(result.value.event),
         });
-        markersRef.current.push(marker);
-      });
-    };
-    drawMarkers();
-  }, [throttledEvents]);
 
-  return <div className="map" style={{ width: '500px', height: '60vh' }} ref={mapRef}></div>;
+        markersRef.current.push(marker);
+        bounds.extend(result.value.position);
+      });
+
+      if (!bounds.isEmpty()) {
+        map.fitBounds(bounds);
+      }
+    };
+
+    drawMarkers();
+  }, [throttledEvents, isMapReady]);
+
+  return (
+    <div className="relative">
+      {!isMapReady && (
+        <div className="absolute inset-0 flex items-center justify-center bg-gray-100 z-10">
+          지도 불러오는 중...
+        </div>
+      )}
+      <div ref={mapRef} style={{ width: '500px', height: '60vh' }} />
+    </div>
+  );
+};
+
+let googleMapsPromise: Promise<void> | null = null;
+
+const loadGoogleMaps = () => {
+  if (googleMapsPromise) return googleMapsPromise;
+
+  googleMapsPromise = new Promise((resolve) => {
+    if (window.google?.maps) {
+      resolve();
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${import.meta.env.VITE_GOOGLE_MAPS_API_KEY}&language=ko`;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    document.head.appendChild(script);
+  });
+
+  return googleMapsPromise;
 };


### PR DESCRIPTION
## 📝 개요 (Summary)

- 기존 index.html에서 전역으로 로드되던 Google Maps API 스크립트를 제거하고, 실제로 지도가 렌더링되는 시점에 동적으로 로드하도록 로직을 변경했습니다. 이를 통해 초기 페이지 진입 속도를 개선하고 불필요한 리소스 낭비를 줄였습니다.
---

## ✨ 주요 변경 사항 (Changes)

- 지도가 필요한 컴포넌트(GoogleMapView)가 마운트될 때 API를 호출하도록 변경했습니다.

- googleMapsPromise를 사용하여 스크립트가 중복으로 로드되지 않도록 싱글톤 패턴을 적용했습니다.

- useState를 도입하여 지도 스크립트 로드 완료 시점에 정확히 리렌더링이 발생하도록 수정했습니다.

---

## 🎯 PR 이유 (Why)

- 초기 로딩 속도 개선: 메인 페이지 등 지도가 없는 화면에서 Google Maps 스크립트를 다운로드하지 않아 FCP/LCP가 개선되었습니다.

- 리소스 최적화: API 호출 비용 및 네트워크 대역폭을 절약 가능

- 사용자 경험 향상: 지도 로딩 상태를 명시적으로 보여주어 UX를 개선할 수 있음

---

## 🧪 테스트 방법 (How to Test)

1. 메인 페이지 접속:

개발자 도구(F12) > Network 탭을 엽니다.

새로고침 후 maps.googleapis.com 관련 요청이 발생하지 않는지 확인합니다.

2. 지도 상세 페이지(TripDetailPage) 진입:

지도가 있는 페이지로 이동합니다.

그 순간 Network 탭에 Google Maps 스크립트 요청이 발생하는지 확인합니다.

지도가 정상적으로 렌더링되고 마커가 표시되는지 확인합니다.

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인

---

## 🗒 기타 (Etc)

> 리뷰어에게 미리 알리고 싶은 내용이나 우려되는 부분이 있다면 작성해주세요.

