### PR TITLE
배포 환경에서 로그아웃이 제대로 안되는 오류

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -2,7 +2,6 @@ import { AuthError } from '../errors/customErrors.ts';
 import { userSchema, type UserResponse } from '../schemas/userSchema.ts';
 import type { GetUserResponse, LogoutResponse } from '../types/auth.ts';
 import { authenticatedClient } from './client/authenticatedClient.ts';
-import { unauthenticatedClient } from './client/unauthenticatedClient.ts';
 import { requestHandler } from './util/requestHandler.ts';
 import z from 'zod';
 
@@ -16,7 +15,7 @@ export const getUserInfoApi = async (): Promise<UserResponse> => {
 
 export const logoutApi = async (): Promise<null> => {
   return requestHandler({
-    request: () => unauthenticatedClient.post<LogoutResponse>('/users/logout'),
+    request: () => authenticatedClient.post<LogoutResponse>('/users/logout'),
     ErrorClass: AuthError,
     schema: z.null(),
   });


### PR DESCRIPTION
## 📝 개요 (Summary)

배포 환경에서 로그아웃이 정상적으로 동작하지 않던 문제를 수정했습니다.

- Cross-Origin 환경에서 로그아웃 요청 시 인증 쿠키가 전달되지 않던 이슈 해결
- 로그아웃 API를 인증 클라이언트 기반으로 통일하여 인증 흐름 안정화

---

## ✨ 주요 변경 사항 (Changes)

- 로그아웃 API 호출 시 unauthenticatedClient → authenticatedClient로 변경
- Axios 요청에 withCredentials: true가 포함된 클라이언트만 사용하도록 구조 정리
- 로그아웃 이후 React Query 캐시에서 사용자 정보(userQueryKeys.info)를 명시적으로 초기화

---

## 🎯 PR 이유 (Why)
해당 프로젝트는 JWT + HttpOnly Cookie 기반 인증 구조를 사용합니다.
- 배포 환경에서는 프론트엔드(new-j-trip.vercel.app)와 서버(trip-j.duckdns.org)가 Cross-Origin 관계입니다.
- 로그아웃 요청 시 withCredentials: true 옵션이 없으면 브라우저가 인증 쿠키를 요청에 포함하지 않습니다.
- 기존 구현에서는 로그아웃 API가 인증 쿠키 없이 호출되어 서버에서 쿠키를 인식하지 못했고 그 결과 로그아웃 처리가 정상적으로 수행되지 않는 문제가 발생했습니다.
- 인증 흐름의 일관성과 보안을 위해 로그아웃 요청 역시 인증 클라이언트 기반으로 처리하도록 수정이 필요했습니다.
---

## 🧪 테스트 방법 (How to Test)

> 로컬에서 리뷰어가 어떻게 테스트할 수 있는지 상세히 적어주세요.
1. 배포 환경에서 /login 페이지 진입
2. Google OAuth 로그인 진행
3. 로그인 성공 후 /auth/user API가 정상적으로 200 응답을 반환하는지 확인
4. 로그아웃 버튼 클릭
5. 서버에서 access_token, refresh_token 쿠키가 삭제되는지 확인
6. 로그아웃 직후 /auth/user 요청 시 401 에러가 반환되는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인

---

## 🗒 기타 (Etc)

> 리뷰어에게 미리 알리고 싶은 내용이나 우려되는 부분이 있다면 작성해주세요.

