### PR TITLE
feature: 중첩 로그인 에러 처리 추가

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -14,13 +14,31 @@ import { Typography } from '../components/common/Typography.tsx';
 import { env } from '../schemas/common/envSchema.ts';
 import { useAuthStatus } from '../hooks/user/useAuthStatus.tsx';
 import { userQueryKeys } from '../constants/queryKeys.ts';
+import { useSearchParams } from 'react-router-dom';
+import toast from 'react-hot-toast';
 
 const WORDS = ['누구나', 'J처럼', '여행하기'];
+
+const LOGIN_ERROR_MESSAGE_MAP: Record<string, string> = {
+  PROVIDER_MISMATCH: '이전에 가입한 플랫폼으로 로그인해주세요.',
+};
 
 export const LoginPage = () => {
   const { user, loading } = useAuthStatus();
   const queryClient = useQueryClient();
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState<number>(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  useEffect(() => {
+    const error = searchParams.get('error');
+    if (!error) return;
+
+    const message = LOGIN_ERROR_MESSAGE_MAP[error] ?? '로그인 중 문제가 발생했습니다.';
+
+    toast.error(message);
+    searchParams.delete('error');
+    setSearchParams(searchParams, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   useEffect(() => {
     const interval = setInterval(() => {


### PR DESCRIPTION
## 📝 개요 (Summary)

- OAuth 로그인 실패 시 에러 코드 기반 리다이렉트 처리 추가  
- LoginPage에서 쿼리 파라미터(`error`)를 파싱해 사용자 안내 UX 개선

---

## ✨ 주요 변경 사항 (Changes)

- OAuth 로그인 실패 시 백엔드에서 `/login?error={ERROR_CODE}` 형태로 리다이렉트하도록 연동
- LoginPage에서 `error` 쿼리 파라미터를 읽어 에러 코드에 맞는 메시지 표시 로직 추가
- 에러 처리 후 URL에서 `error` 파라미터를 제거하여 중복 노출 방지
- 에러 메시지는 프론트엔드에서만 관리하도록 분리 (서버는 enum 형태의 코드만 전달)

---

## 🎯 PR 이유 (Why)

- OAuth 콜백은 전체 페이지 리다이렉트 방식이기 때문에 JSON 응답 기반 에러 처리가 불가능함
- 에러 메시지를 URL에 그대로 노출하는 방식은 보안 및 UX 측면에서 부적절함
- 최소한의 에러 식별자(error code)만 전달하고, 실제 사용자 메시지는 프론트엔드에서 처리하는 구조가 필요했음
- 로그인 실패 원인에 따른 명확한 사용자 안내를 제공하기 위함

---

## 🧪 테스트 방법 (How to Test)

1. OAuth 로그인 시 잘못된 provider로 로그인 시도  
   - 예: 이미 카카오로 가입된 계정으로 네이버 로그인 시도
2. `/login?error=PROVIDER_MISMATCH` 형태로 리다이렉트되는지 확인
3. LoginPage에서 에러 메시지가 정상적으로 노출되는지 확인
4. 페이지 새로고침 시 에러 메시지가 다시 노출되지 않는지 확인
5. 정상 provider로 로그인 시 정상적으로 홈(`/`)으로 이동하는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [X] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인  

---

## 🗒 기타 (Etc)
