### PR TITLE
이벤트 제목, 장소 입력 시 trim 적용

### DIFF
--- a/src/components/event/EventTitleLocationStep.tsx
+++ b/src/components/event/EventTitleLocationStep.tsx
@@ -131,7 +131,11 @@ export const EventTitleLocationStep = ({ setStep }: EventTitleLocationStepProps)
         <Input
           type="text"
           placeholder="예) 식당 예약"
-          {...register('eventName')}
+          {...register('eventName', {
+            onBlur: (e) => {
+              setValue('eventName', e.target.value.trim(), { shouldValidate: true });
+            },
+          })}
           containerClassName="w-full"
         />
       </div>
@@ -153,7 +157,11 @@ export const EventTitleLocationStep = ({ setStep }: EventTitleLocationStepProps)
         <div className="flex items-center gap-3 border border-gray-300 dark:border-gray-700 rounded-lg px-4 py-3 focus-within:ring-2 focus-within:ring-primary-base focus-within:border-transparent transition-all bg-white dark:bg-slate-900">
           <Input
             type="text"
-            {...register('location')}
+            {...register('location', {
+              onBlur: (e) => {
+                setValue('location', e.target.value.trim(), { shouldValidate: true });
+              },
+            })}
             placeholder="예) 서울"
             autoComplete="off"
             containerClassName="w-full"


### PR DESCRIPTION
## 📝 개요 (Summary)

이벤트 생성/수정 시 제목과 장소 입력값의 앞뒤 공백이 제거되지 않아 의도하지 않은 공백이 포함되어 저장되는 문제를 개선했습니다.  
입력 단계에서 `trim()`을 적용하고, 공백만 입력된 경우에는 유효성 검사에 걸리도록 처리하여 데이터 품질과 UX를 함께 개선했습니다.

---

## ✨ 주요 변경 사항 (Changes)

- **이벤트 제목(title) input**
  - submit 전 입력값에 `trim()` 적용
  - 앞뒤 공백이 포함된 문자열이 그대로 저장되지 않도록 처리
  - 공백만 입력된 경우 validation 에러 처리

- **이벤트 장소(location) input**
  - submit 전 입력값에 `trim()` 적용
  - 의미 없는 공백 문자열 저장 방지
  - 공백만 입력된 경우 validation 에러 처리

- **Validation 로직 보강**
  - 빈 문자열(`''`)뿐 아니라 `trim()` 이후 빈 값도 invalid 처리
  - 사용자에게 즉시 피드백 제공

---

## 🎯 PR 이유 (Why)

- 이벤트 제목/장소에 앞뒤 공백이 포함된 채 저장되면
  - 리스트 및 지도 화면에서 정렬/표시가 어색해지고
  - 검색, 비교 로직에서 불필요한 예외 케이스가 발생할 수 있습니다.
- 공백만 입력된 값은 실질적인 의미가 없는 데이터이므로,
  입력 단계에서 차단해 **데이터 품질과 UX를 동시에 개선**할 필요가 있었습니다.

---

## 🧪 테스트 방법 (How to Test)

1. 이벤트 생성 또는 수정 화면으로 이동
2. 제목 또는 장소에 다음과 같이 입력
   - `"  여행 첫날 일정  "` (앞뒤 공백 포함)
   - `"     "` (공백만 입력)
3. 저장 버튼 클릭
4. 확인 사항
   - 앞뒤 공백이 제거된 값으로 저장되는지 확인
   - 공백만 입력한 경우 validation 에러가 노출되는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인

---

## 🗒 기타 (Etc)

> 리뷰어에게 미리 알리고 싶은 내용이나 우려되는 부분이 있다면 작성해주세요.

