### PR TITLE
수정 화면에서 input trim 미적용으로 공백 값이 남아있는 문제

### DIFF
--- a/src/pages/EventEditPage.tsx
+++ b/src/pages/EventEditPage.tsx
@@ -41,8 +41,8 @@ export const EventEditPage = () => {
 
   useEffect(() => {
     form.reset({
-      eventName: eventDetail.eventName,
-      location: eventDetail.location,
+      eventName: eventDetail.eventName?.trim() || '',
+      location: eventDetail.location?.trim() || '',
       startDate: eventDetail.startDate,
       endDate: eventDetail.endDate,
       cost: eventDetail.cost,

--- a/src/pages/TripEditPage.tsx
+++ b/src/pages/TripEditPage.tsx
@@ -47,7 +47,7 @@ export const TripEditPage = () => {
       startDate: tripDetail.startDate,
       endDate: tripDetail.endDate,
       members: tripDetail.members,
-      title: tripDetail.title,
+      title: tripDetail.title?.trim() || '',
       createdBy: tripDetail.createdBy,
     });
   }, [tripDetail, form]);


### PR DESCRIPTION
## 📝 개요 (Summary)

- 수정(Edit) 화면 form reset 시점에서 input 값 trim 처리
- 생성/수정 간 입력값 표시 불일치 문제 해결

---

## ✨ 주요 변경 사항 (Changes)

- Edit 화면에서 서버 데이터를 form에 바인딩할 때
  - `form.reset()` 호출 시점에 `trim()` 적용
- reset 시 전달되는 초기값을 기준으로 공백 제거
  - 화면에 표시되는 값과 서버에 저장된 값 간 불일치 제거
- 기존 Create 흐름의 trim 로직과 동작 기준을 맞춰
  - 생성/수정 모두 동일한 입력 정제 정책 유지

---

## 🎯 PR 이유 (Why)

- 생성(Create) 시에는 서버에 trim 된 값이 저장되지만  
  수정(Edit) 화면에서는 reset 과정에서 이전 공백 값이 그대로 노출되는 문제가 있었음
- 이로 인해 **실제 저장된 값과 화면에 보이는 값이 불일치**하는 UX 이슈 발생
- form reset 단계에서 값을 정제함으로써
  - 서버 상태 기준으로 화면을 일관되게 유지하기 위함

---

## 🧪 테스트 방법 (How to Test)

1. 생성(Create) 화면에서 앞/뒤 공백 포함 입력 후 저장  
   - 예: `"  부산 여행  "`
2. 서버에 공백이 제거된 값으로 저장되었는지 확인  
   - `"부산 여행"`
3. 수정(Edit) 화면 진입
4. form reset 이후 input에 공백 없이 값이 표시되는지 확인
5. 수정 후 저장 → 재진입 시에도 동일한 값 유지되는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인  

---

## 🗒 기타 (Etc)

- 입력 중 UX 이슈를 피하기 위해 `onChange`가 아닌  
  **form reset 단계에서 trim 처리**함
- 추후 모든 입력을 강제 정제해야 할 경우 공통 유틸로 확장 가능