### PR TITLE
경비 입력 시 숫자 아닌 값 입력하면 전부 지워지는 문제 수정

### DIFF
--- a/src/components/event/EventCostAndSubmitStep.tsx
+++ b/src/components/event/EventCostAndSubmitStep.tsx
@@ -252,8 +252,15 @@ export const EventCostAndSubmitStep = ({ setStep, mode }: EventCostAndSubmitStep
                 placeholder="0"
                 value={item.value ? String(item.value) : ''}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  updateCost(item.id, { value: Number(e.target.value) })
-                }
+                   {const inputValue = e.target.value;                  
+                    if (inputValue === '') {
+                    updateCost(item.id, { value: 0 });
+                    return;
+                  }
+                    if (/^\d+$/.test(inputValue)) {
+                    updateCost(item.id, { value: Number(inputValue) });
+                  }
+                }}
                 className="py-3 text-right"
               />
               <span className="ml-1 text-sm text-gray-500 dark:text-gray-400">원</span>


### PR DESCRIPTION
## 📝 개요 (Summary)

- 경비 입력 필드에서 숫자가 아닌 입력 시 전체 값이 삭제되는 문제 해결
- 잘못된 입력은 무시하고 기존 입력값을 유지하도록 입력 처리 로직 개선

---

## ✨ 주요 변경 사항 (Changes)

- 경비 금액 입력 필드의 입력 처리 로직 수정
  - 숫자가 아닌 문자/특수문자 입력 시 기존 값 유지
  - 허용되지 않는 입력은 상태 업데이트에서 제외
- 입력 중간 상태에 대한 처리 방식 정리
  - 빈 문자열(`''`) 등 타이핑 과정에서 발생하는 값은 정상 흐름으로 허용
- validation 적용 방식 개선
  - 입력 즉시 전체 값을 초기화하지 않고
  - 사용자 입력 흐름을 방해하지 않는 방향으로 동작하도록 수정

---

## 🎯 PR 이유 (Why)

- 숫자만 허용되는 입력 필드에서 문자 입력 시 기존 값까지 모두 삭제되어
  사용자 입장에서 실수 한 번에 재입력이 필요한 UX 문제가 있었음
- 사용자는 잘못 입력한 **한 글자만 무시**되길 기대하므로,
  입력값을 보호하면서도 자연스러운 validation 처리가 필요했음

---

## 🧪 테스트 방법 (How to Test)

1. 경비 추가 또는 수정 화면으로 이동
2. 숫자를 연속으로 입력 (예: `12345`)
3. 문자 또는 특수문자 입력 시도 (예: `a`, `!`)
   - 기존 숫자 값이 유지되는지 확인
4. 다시 숫자 입력 시 정상적으로 이어서 입력되는지 확인
5. 입력 중 값이 갑자기 초기화되거나 사라지지 않는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인  

---

## 🗒 기타 (Etc)
