### PR TITLE
여행 수정 시 홈 화면 데이터 즉시 반영

### DIFF
--- a/src/components/trip/TripTitleAndSubmitStep.tsx
+++ b/src/components/trip/TripTitleAndSubmitStep.tsx
@@ -88,7 +88,7 @@ export const TripTitleAndSubmitStep = ({ setStep, mode }: TripTitleAndSubmitStep
       return { previousDetail };
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: tripQueryKeys.detail(tripIdNumber) });
+        queryClient.invalidateQueries({ queryKey: tripQueryKeys.all });
     },
     onSuccess: () => {
       toast.success('여행 수정에 성공했습니다.');


### PR DESCRIPTION
## 📝 개요 (Summary)

- 여행 수정(Trip Edit) 완료 후 홈 화면에 수정 내용이 즉시 반영되도록 React Query 캐시 갱신 로직을 개선했습니다.
- 여행 수정 성공 시 모든 trip 관련 쿼리를 무효화하여 데이터 불일치 문제를 해결했습니다.

---

## ✨ 주요 변경 사항 (Changes)

- 여행 수정 API 성공 이후 `tripQueryKeys.all` 기준으로 React Query 캐시 무효화 처리
- 여행 상세 수정 시 optimistic update 이후, 목록 데이터가 최신 상태로 다시 fetch 되도록 수정
- 홈 화면에서 사용하는 여행 목록 쿼리가 항상 최신 데이터를 참조하도록 보장

---

## 🎯 PR 이유 (Why)

- 기존에는 여행 수정 이후 **홈 화면의 여행 목록 쿼리가 갱신되지 않아**
  수정된 정보가 즉시 반영되지 않는 문제가 있었습니다.
- React Query 캐시에 이전 데이터가 남아 있어 사용자가 새로고침을 해야만
  올바른 데이터를 확인할 수 있는 UX 문제가 발생했습니다.
- 여행 수정 시점에 trip 관련 쿼리를 명확히 무효화하여
  **캐시 일관성과 사용자 경험을 동시에 개선**하기 위해 해당 변경을 진행했습니다.

---

## 🧪 테스트 방법 (How to Test)

1. 홈 화면에서 여행 목록 확인
2. 특정 여행 선택 후 여행 수정 페이지로 이동
3. 여행 제목 또는 정보 수정 후 저장
4. 홈 화면으로 이동
5. 수정한 여행 정보가 즉시 반영되는지 확인

---


## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인

---

## 🗒 기타 (Etc)

> 리뷰어에게 미리 알리고 싶은 내용이나 우려되는 부분이 있다면 작성해주세요.

