### PR TITLE
여행 수정시 멤버에 내가 뜨는 오류 해결

### DIFF
--- a/src/components/trip/TripMembersStep.tsx
+++ b/src/components/trip/TripMembersStep.tsx
@@ -16,12 +16,14 @@ import {
   useSearchUsersQueryOptions,
   useUsersByEmailsQueryOptions,
 } from '../../hooks/query/user.ts';
+import { useAuthStatus } from '../../hooks/user/useAuthStatus.tsx';
 
 interface TripMembersStepProps {
   setStep: (step: number) => void;
 }
 
 export const TripMembersStep = ({ setStep }: TripMembersStepProps) => {
+  const { user } = useAuthStatus();
   const { setValue, watch } = useFormContext<TripFormValues>();
   const members = watch('members');
   const [searchValue, setSearchValue] = useState<string>('');
@@ -53,10 +55,11 @@ export const TripMembersStep = ({ setStep }: TripMembersStepProps) => {
   const selectedMembers = useMemo(() => {
     const allUsers = [...usersByEmails, ...locallyAddedUsers];
 
-    return members.map((email) => {
+    return members.filter((email) => email !== user?.email)
+    .map((email) => {
       return allUsers.find((user) => user.email === email);
-    });
-  }, [usersByEmails, locallyAddedUsers, members]);
+      });
+    }, [usersByEmails, locallyAddedUsers, members, user?.email]);
 
   const addMember = (user: UserSummary) => {
     if (!members.includes(user.email)) {
@@ -73,6 +76,7 @@ export const TripMembersStep = ({ setStep }: TripMembersStepProps) => {
       members.filter((m) => m !== email)
     );
   };
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex gap-2 flex-col justify-center mt-4 mx-4 min-h-[70px]">


### PR DESCRIPTION
## 📝 개요 (Summary)

- 여행 수정 화면에서 **로그인 유저 본인**이 멤버 UI에 노출되던 문제를 해결했습니다.
- 멤버 데이터는 유지하되, **동행자 표시/선택 영역에서 본인을 제외**하도록 로직을 수정했습니다.

---

## ✨ 주요 변경 사항 (Changes)

- `TripMembersStep`에서 선택된 멤버를 구성하는 `selectedMembers` 계산 로직 수정
  - `members`(email 리스트) → 표시용 유저(UserSummary) 매핑 시
  - **로그인 유저 이메일(myEmail)을 필터링**하여 멤버 칩(UI)에 노출되지 않도록 처리
  - “함께 가는 사람” UI의 의미를 동행자 중심으로 정리
  - 본인 노출로 인한 UX 혼란 및 중복 선택 가능성 제거

---

## 🎯 PR 이유 (Why)

- 여행 생성 시 로그인 유저는 자동으로 멤버에 포함되는데,
- 여행 수정 화면에서는 이 값이 그대로 `selectedMembers`에 반영되며
  - 본인이 멤버 UI에 다시 노출되어
  - “내가 이미 멤버인데 왜 또 보이지?”라는 UX 혼란을 유발했습니다.
- 따라서 **데이터 구조는 유지**하면서, UI에서만 **로그인 유저를 제외**해 동행자 UI 목적에 맞게 개선했습니다.

---

## 🧪 테스트 방법 (How to Test)

1. 로그인 후 여행 생성 (본인은 자동으로 멤버 포함)
2. 생성된 여행의 수정 페이지로 이동
3. 멤버 수정 화면(TripMembersStep) 확인
4. 로그인 유저 본인이 멤버 칩(UI)에 노출되지 않는지 확인
5. 다른 멤버 추가/삭제 동작이 정상 동작하는지 확인

---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 린트/포맷 적용 완료  
- [x] 브레이킹 체인지 여부 확인 (없음)  
- [x] 불필요한 console.log 제거  
- [x] 주석/테스트 코드 확인  

---

## 🗒 기타 (Etc)
