### PR TITLE
Production 배포 TimeZone 설정 추가

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   Deploy-Production:
     runs-on: ubuntu-latest
+    env:
+      TZ: Asia/Seoul
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## 📝 개요 (Summary)

Production 배포 GitHub Actions 워크플로우에 **TimeZone(Asia/Seoul) 설정을 추가**하여  
CI 환경과 로컬/운영 환경 간의 시간 기준 차이로 발생할 수 있는 문제를 방지했습니다.

---

## ✨ 주요 변경 사항 (Changes)

- Production 배포 GitHub Actions Job에 `TZ=Asia/Seoul` 환경 변수 추가
- 테스트 및 빌드 단계에서 시간 기준이 UTC가 아닌 **KST 기준으로 동작하도록 통일**
- 날짜/시간 관련 유틸 및 테스트가 로컬 환경과 동일한 기준으로 실행되도록 개선

---

## 🎯 PR 이유 (Why)

- GitHub Actions 기본 실행 환경은 UTC 기준으로 동작함
- 이로 인해 날짜/시간 포맷팅 유틸 테스트 및 실제 런타임 동작에서
  로컬(Asia/Seoul) 환경과 다른 결과가 발생할 가능성이 있었음
- Production 배포 환경에서도 명확한 시간 기준을 적용해
  **환경 차이로 인한 예기치 않은 버그를 사전에 방지**하기 위함

---

## 🧪 테스트 방법 (How to Test)

1. Production 배포 워크플로우 실행 (`main` 브랜치 push)
2. GitHub Actions 로그에서 `TZ=Asia/Seoul` 환경 변수가 적용되었는지 확인
3. 날짜/시간 관련 테스트(`formatTimeDisplay` 등)가 정상적으로 통과하는지 확인


---

## ✔ 체크리스트 (Checklist)

- [x] 빌드 및 타입 체크 통과  
- [x] 테스트 정상 통과  
- [x] TimeZone 설정으로 인한 브레이킹 체인지 여부 확인  
- [x] 불필요한 로그 제거  
- [x] CI / Production 환경 시간 기준 일관성 확보  

---

## 🗒 기타 (Etc)

- Preview / Production 배포 모두 동일한 TimeZone 기준을 유지하도록 설정됨
- UTC 기준 시간이 필요한 로직이 추가될 경우, 명시적인 변환 로직이 필요할 수 있음